### PR TITLE
Add a responsive design on the about section

### DIFF
--- a/components/about.js
+++ b/components/about.js
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import styles from './about.module.css';
 import utilsStyles from '../styles/utils.module.css';
 import { BsTwitter, BsInstagram } from 'react-icons/bs';
-import { FaFacebookF } from 'react-icons/fa';
 import { GrFacebookOption } from 'react-icons/gr';
 
 export default function About() {
@@ -22,6 +21,7 @@ export default function About() {
 						src="/assets/sample_profile_pic.jpeg"
 						layout="fill"
 						objectFit="cover"
+						objectPosition="left top"
 						alt="profile-dummy"
 					/>
 				</div>

--- a/components/about.module.css
+++ b/components/about.module.css
@@ -75,4 +75,41 @@
 
 /*================ Laptop ==================*/
 @media screen and (min-width: 1024px) {
+	.about_section_container {
+		grid-template-columns: 50% 50%;
+		grid-template-rows: 1fr 0.5fr 3fr 1fr;
+		grid-template-areas:
+			'h2 h2'
+			'img h3'
+			'img description'
+			'. social';
+	}
+
+	.about_section_container h2 {
+		grid-area: h2;
+	}
+
+	.about_section_container h3 {
+		grid-area: h3;
+	}
+
+	.image_wrapper {
+		grid-area: img;
+	}
+
+	.description {
+		grid-area: description;
+		height: auto;
+		max-height: 100%;
+		align-self: center;
+	}
+
+	.social_icons {
+		grid-area: social;
+	}
+
+	.social_icons svg {
+		width: 3rem;
+		height: 3rem;
+	}
 }

--- a/components/about.module.css
+++ b/components/about.module.css
@@ -56,3 +56,23 @@
 .social_icons svg:hover {
 	color: var(--accent-color);
 }
+
+/*================ Tablet ==================*/
+@media screen and (min-width: 768px) {
+	.about_section {
+		padding: 0 10rem;
+	}
+
+	.social_icons {
+		gap: 4rem;
+	}
+
+	.social_icons svg {
+		width: 2.5rem;
+		height: 2.5rem;
+	}
+}
+
+/*================ Laptop ==================*/
+@media screen and (min-width: 1024px) {
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -91,15 +91,16 @@ a:hover {
 	}
 
 	h2 {
-		font-size: 2.5rem;
+		font-size: 4rem;
 	}
 
 	h3 {
-		font-size: 1.5rem;
+		font-size: 2.8rem;
 	}
 
 	p {
-		font-size: 1.2rem;
-		line-height: 2.2rem;
+		font-size: 2rem;
+		line-height: 3.8rem;
+		margin-bottom: 4rem;
 	}
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -37,15 +37,15 @@ h2 {
 }
 
 h3 {
-	font-size: 1.5rem;
+	font-size: 1.8rem;
 }
 
 p {
 	font-family: var(--text-font);
-	font-size: 1.2rem;
-	line-height: 2.2rem;
+	font-size: 1.4rem;
+	line-height: 2.8rem;
 	margin: 0;
-	margin-bottom: 1rem;
+	margin-bottom: 2rem;
 }
 
 a {
@@ -61,4 +61,45 @@ a:hover {
 	padding: 0;
 	margin: 0;
 	box-sizing: border-box;
+}
+
+/*================ Tablet ==================*/
+@media screen and (min-width: 768px) {
+	h1 {
+		font-size: 4rem;
+	}
+
+	h2 {
+		font-size: 3rem;
+	}
+
+	h3 {
+		font-size: 2.2rem;
+	}
+
+	p {
+		font-size: 1.8rem;
+		line-height: 3.2rem;
+		margin-bottom: 2.5rem;
+	}
+}
+
+/*================ Laptop ==================*/
+@media screen and (min-width: 1024px) {
+	h1 {
+		font-size: 4rem;
+	}
+
+	h2 {
+		font-size: 2.5rem;
+	}
+
+	h3 {
+		font-size: 1.5rem;
+	}
+
+	p {
+		font-size: 1.2rem;
+		line-height: 2.2rem;
+	}
 }


### PR DESCRIPTION
I added a responsive design on the about section.
For tablets (`min-width: 768px`) and laptops and bigger devices (`min-width: 1024px`).

Also, I updated `styles/globals.css` file as well to have the same font size on each section.
🚨  @Shiho317 I haven't changed the font size of `h1` since we only use `h1` on the hero section. Please adjust it later.

Please check the code and the design on your browser.

Thanks!