### PR TITLE
Add the image placeholder and fix errors

### DIFF
--- a/components/about.js
+++ b/components/about.js
@@ -4,6 +4,7 @@ import styles from './about.module.css';
 import utilsStyles from '../styles/utils.module.css';
 import { BsTwitter, BsInstagram } from 'react-icons/bs';
 import { GrFacebookOption } from 'react-icons/gr';
+import { shimmer, toBase64 } from '../utils/shimmer';
 
 export default function About() {
 	return (
@@ -23,6 +24,8 @@ export default function About() {
 						objectFit="cover"
 						objectPosition="left top"
 						alt="profile-dummy"
+						placeholder="blur"
+						blurDataURL={`data:image/svg+xml;base64,${toBase64(shimmer())}`}
 					/>
 				</div>
 				<h3 className={`${utilsStyles.font_white} ${styles.about_section}`}>

--- a/components/about.js
+++ b/components/about.js
@@ -18,7 +18,6 @@ export default function About() {
 				</h2>
 				<div className={styles.image_wrapper}>
 					<Image
-						priority
 						src="/assets/sample_profile_pic.jpeg"
 						layout="fill"
 						objectFit="cover"
@@ -47,13 +46,19 @@ export default function About() {
 				</div>
 				<article className={styles.social_icons}>
 					<Link href="/" passHref>
-						<BsTwitter size="1.5rem" />
+						<>
+							<BsTwitter size="1.5rem" />
+						</>
 					</Link>
 					<Link href="/" passHref>
-						<GrFacebookOption size="1.5rem" />
+						<>
+							<GrFacebookOption size="1.5rem" />
+						</>
 					</Link>
 					<Link href="/" passHref>
-						<BsInstagram size="1.5rem" />
+						<>
+							<BsInstagram size="1.5rem" />
+						</>
 					</Link>
 				</article>
 			</div>

--- a/utils/shimmer.js
+++ b/utils/shimmer.js
@@ -1,0 +1,20 @@
+const shimmer = () => `
+<svg width="100%" height="100%" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="g">
+      <stop stop-color="#333" offset="20%" />
+      <stop stop-color="#222" offset="50%" />
+      <stop stop-color="#333" offset="70%" />
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="#333" />
+  <rect id="r" width="100%" height="100%" fill="url(#g)" />
+  <animate xlink:href="#r" attributeName="x" from="-100%" to="100%" dur="1s" repeatCount="indefinite"  />
+</svg>`;
+
+const toBase64 = (str) =>
+	typeof window === 'undefined'
+		? Buffer.from(str).toString('base64')
+		: window.btoa(str);
+
+export { shimmer, toBase64 };


### PR DESCRIPTION
Hi 👋

I implemented [the image placeholder](https://nextjs.org/docs/api-reference/next/image#placeholder) for the profile image on the "About" section.
I referred to [this placeholder](https://image-component.nextjs.gallery/shimmer).
While loading the image, the shimmer & blur image placeholder should be shown in the position.

Please check if it works on your browser as well.

Also, there is an error message on the console like the capture and I solved it.
![スクリーンショット 2021-12-23 0 54 31](https://user-images.githubusercontent.com/51708229/147217240-90287a24-19e2-4d9f-8c09-a212624e10b2.png)
This was because each social icon in the "About" section was directly wrapped by the `Link` component.
Referring to[ this StackOverflow answer](https://stackoverflow.com/a/69767229), I wrapped each icon with a fragment.

That's it!

Thanks🎄 ✨ 