### PR TITLE
Update some details

### DIFF
--- a/components/about.module.css
+++ b/components/about.module.css
@@ -36,7 +36,7 @@
 }
 
 .description p {
-	word-break: break-word;
+	word-break: normal;
 }
 
 .social_icons {
@@ -61,11 +61,6 @@
 @media screen and (min-width: 768px) {
 	.about_section {
 		padding: 0 10rem;
-	}
-
-	.description p{
-		text-align: justify;
-  text-justify: inter-character;
 	}
 
 	.social_icons {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,7 @@
 
 :root {
 	--title-font: 'Notable', sans-serif;
-	--text-font: merriweather, serif;
+	--text-font: 'Enriqueta', serif;
 	--accent-color: #ff0303;
 }
 
@@ -20,6 +20,7 @@ html,
 body {
 	width: 100vw;
 	font-size: 62.5%;
+	overflow-x: hidden;
 }
 
 h1,


### PR DESCRIPTION
Hi everyone 👋 

I updated some parts and they are the ones following:

1. The text font
As I mentioned in the chat, the font text changed to `marriweather` which is also "serif".
I got it back to the original font as we designed on Figma for now.

2. The About section's description - word-break
`word-break: break-word` is now [deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break), so replaced with `word-break: normal` which works the same way.
```css
.description p{
		text-align: justify;
  text-justify: inter-character;
	}
```
Also, `text-justify: inter-character` is not valid.  I found it out in Dev Tool.

`text-align: justify` makes the entire paragraph expanded to the sides and the space between each word would stand out in a bad way.

🔽  with `text-align: justify`
![スクリーンショット 2022-01-27 23 43 59](https://user-images.githubusercontent.com/51708229/151508678-794d8b08-66fe-450e-9e4a-b927258493e0.png)

🔽  without `text-align: justify` as same as `text-align: start` (default)
![スクリーンショット 2022-01-27 23 39 53](https://user-images.githubusercontent.com/51708229/151509015-1867eb68-35b6-47c0-9ba4-9cef1eeb9dbf.png)

3.  The horizontal scroll bar
I found there is an unnecessary horizontal scroll bar, so I removed it.


That's all from me.
Please check how it looks on your browser.

Thanks.